### PR TITLE
Declare the module with full path

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+
 	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
-	"inventory-client-go/v1beta1"
+	"github.com/project-kessel/inventory-client-go/v1beta1"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
-module inventory-client-go
+module github.com/project-kessel/inventory-client-go
 
 go 1.22.5
 
-toolchain go1.22.6
-
 require (
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/project-kessel/inventory-api v0.0.0-20240902141731-aad011c715fd
@@ -18,7 +17,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/go-kratos/aegis v0.2.0 // indirect
-	github.com/go-kratos/kratos/v2 v2.8.0 // indirect
 	github.com/go-playground/form/v4 v4.2.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/http-ex/main.go
+++ b/http-ex/main.go
@@ -3,17 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
+
 	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
-	"inventory-client-go/v1beta1"
+	"github.com/project-kessel/inventory-client-go/v1beta1"
 )
 
 func main() {
-
 	client, err := v1beta1.NewHttpClient(context.Background(),
 		v1beta1.NewConfig(v1beta1.WithHTTPUrl("localhost:8081")))
 	v1beta1.WithTLSInsecure(true)
-	//v1beta1.WithAuthEnabled("svc-test", "", "http://localhost:8084/realms/redhat-external/protocol/openid-connect/token"),
-	//v1beta1.WithHTTPTLSConfig(tls.Config{})
+	// v1beta1.WithAuthEnabled("svc-test", "", "http://localhost:8084/realms/redhat-external/protocol/openid-connect/token"),
+	// v1beta1.WithHTTPTLSConfig(tls.Config{})
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -31,7 +31,7 @@ func main() {
 			ReporterVersion:    "0.1",
 		},
 	}}
-	//optts, err := client.GetTokenHTTPOption()
+	// optts, err := client.GetTokenHTTPOption()
 	resp, err := client.RhelHostServiceClient.CreateRhelHost(context.Background(), &request)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Declaring the module with a shortened path like `inventory-client-go` instead of the full path `github.com/project-kessel/inventory-client-go` in the `go.mod` file can lead to several issues, especially when other projects use the module. Here are the main problems:

Go modules are identified by their full path, typically a URL to the repository (e.g., `github.com/project-kessel/inventory-client-go`). When the module path in `go.mod` doesn't match the repository URL, Go's module resolution system gets confused. This leads to errors like the one you're encountering (`module declares its path as: inventory-client-go but was required as: github.com/project-kessel/inventory-client-go`).


It's essential to declare the module path in the `go.mod` file using the full URL (`github.com/project-kessel/inventory-client-go`). Doing so ensures that Go can resolve, fetch, and manage the module correctly, avoids import path conflicts, and makes the module easier to use in other projects.