### PR TITLE
Add support for http.Timeout config

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1,6 +1,9 @@
 package common
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"time"
+)
 
 type Config struct {
 	Insecure           bool
@@ -11,6 +14,7 @@ type Config struct {
 	clientSecret       string
 	authServerTokenUrl string
 	TlsConfig          *tls.Config
+	Timeout            time.Duration
 }
 
 type ClientOptions func(*Config)
@@ -46,6 +50,12 @@ func WithHTTPTLSConfig(tlsConfig *tls.Config) ClientOptions {
 	return func(c *Config) {
 		c.Insecure = false
 		c.TlsConfig = tlsConfig
+	}
+}
+
+func WithTimeout(timeout time.Duration) ClientOptions {
+	return func(c *Config) {
+		c.Timeout = timeout
 	}
 }
 

--- a/v1beta1/client.go
+++ b/v1beta1/client.go
@@ -3,8 +3,9 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"github.com/project-kessel/inventory-client-go/common"
 	nethttp "net/http"
+
+	"github.com/project-kessel/inventory-client-go/common"
 
 	"github.com/authzed/grpcutil"
 	"github.com/go-kratos/kratos/v2/transport/http"
@@ -90,6 +91,10 @@ func NewHttpClient(ctx context.Context, config *common.Config) (*InventoryHttpCl
 
 	if !config.Insecure {
 		opts = append(opts, http.WithTLSConfig(config.TlsConfig))
+	}
+
+	if config.Timeout > 0 {
+		opts = append(opts, http.WithTimeout(config.Timeout))
 	}
 
 	client, err := http.NewClient(ctx, opts...)

--- a/v1beta2/client.go
+++ b/v1beta2/client.go
@@ -3,8 +3,9 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"github.com/project-kessel/inventory-client-go/common"
 	nethttp "net/http"
+
+	"github.com/project-kessel/inventory-client-go/common"
 
 	"github.com/authzed/grpcutil"
 	"github.com/go-kratos/kratos/v2/transport/http"
@@ -83,6 +84,10 @@ func NewHttpClient(ctx context.Context, config *common.Config) (*InventoryHttpCl
 
 	if !config.Insecure {
 		opts = append(opts, http.WithTLSConfig(config.TlsConfig))
+	}
+
+	if config.Timeout > 0 {
+		opts = append(opts, http.WithTimeout(config.Timeout))
 	}
 
 	client, err := http.NewClient(ctx, opts...)


### PR DESCRIPTION
- Adds support for defining a timeout via http client config (kratos default is 2000ms)

## Summary by Sourcery

Add configurable HTTP client timeout support across different API versions

New Features:
- Introduce a configurable timeout option for HTTP clients with a default of 2000ms

Enhancements:
- Extend the common Config struct to include a Timeout field of type time.Duration
- Update HTTP client creation in v1beta1 and v1beta2 to support optional timeout configuration