### PR TITLE
minor bug fixes

### DIFF
--- a/examples/v1beta2-ex/main.go
+++ b/examples/v1beta2-ex/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-client-go/common"
 	v1beta2 "github.com/project-kessel/inventory-client-go/v1beta2"
@@ -33,7 +34,7 @@ func main() {
 	}
 	request := kesselv2.ReportResourceRequest{
 		Type:               "host",
-		ReporterType:       "HBI",
+		ReporterType:       "hbi",
 		ReporterInstanceId: "1",
 		Representations: &kesselv2.ResourceRepresentations{
 			Metadata: &kesselv2.RepresentationMetadata{

--- a/v1beta2/client.go
+++ b/v1beta2/client.go
@@ -1,4 +1,4 @@
-package v1beta1
+package v1beta2
 
 import (
 	"context"


### PR DESCRIPTION
* updates package name for v1beta2 client to reflect v1beta2
* fixes error in example code as using "HBI" triggers a validation failure as "hbi" is the available option

## Summary by Sourcery

Update v1beta2 client package name and fix the reporter type in the example code

Bug Fixes:
- Use valid lowercase reporter type "hbi" in example to avoid validation failure

Enhancements:
- Update v1beta2 client package name to reflect the current version